### PR TITLE
Fixed error “Class 'cache.toolbar' not found”

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -18,19 +18,21 @@
  * module.config.php
  * @data:       2017-02-08 19:36
  */
-
-use DoctrineCacheToolbar\Factory\Collector\CacheCollectorFactory;
+namespace DoctrineCacheToolbar;
 
 return [
     'service_manager' => [
+        'aliases' => [
+            'cache.toolbar' => Collector\CacheCollector::class,
+        ],
         'factories' => [
-            'cache.toolbar' => CacheCollectorFactory::class
+            Collector\CacheCollector::class => Factory\Collector\CacheCollectorFactory::class,
         ],
     ],
     'view_manager' => [
         'template_map' => [
             'zend-developer-tools/toolbar/cache-data' => __DIR__.'/../view/zend-developer-tools/toolbar/cache-data.phtml',
-        ]
+        ],
     ],
     'zenddevelopertools' => [
         'profiler' => [
@@ -45,3 +47,4 @@ return [
         ],
     ],
 ];
+


### PR DESCRIPTION
In Zend ServiceManager V3 the $name param crashes in line 45, because "cache.toolbar" is alias not class.
Migrate "cache.toolbar" to aliases and create factory using CacheCollector class.